### PR TITLE
feat: add type="security" field to all OWASP log events

### DIFF
--- a/src/owasp_logger/logger.py
+++ b/src/owasp_logger/logger.py
@@ -27,6 +27,7 @@ class OWASPLogger:
         """Emit an OWASP-compliant log."""
         log = OWASPLogEvent(
             datetime=datetime.now(timezone.utc).astimezone().isoformat(),
+            type="security",
             appid=self.appid,
             event=event,
             level=logging.getLevelName(level),

--- a/src/owasp_logger/model.py
+++ b/src/owasp_logger/model.py
@@ -8,6 +8,7 @@ NESTED_JSON_KEY = "owasp_event"
 @dataclass
 class OWASPLogEvent:
     datetime: str  # ISO8601 timestamp with timezone
+    type: str  # Log type, always "security" for OWASP events
     appid: str
     event: str  # The type of event being logged (i.e. sys_crash)
     level: str  # Log level reflecting the importance of the event

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,2 +1,0 @@
-def test_placeholder():
-    assert True

--- a/tests/test_type_security.py
+++ b/tests/test_type_security.py
@@ -1,0 +1,93 @@
+import json
+import logging
+
+from owasp_logger import OWASPLogger
+from owasp_logger.model import NESTED_JSON_KEY, OWASPLogEvent
+
+
+class TestOWASPLogEventTypeField:
+    """Ensure all OWASP log events include type='security'."""
+
+    def test_type_field_in_dataclass(self):
+        event = OWASPLogEvent(
+            datetime="2026-01-01T00:00:00+00:00",
+            type="security",
+            appid="test.app",
+            event="test_event",
+            level="INFO",
+        )
+        assert event.type == "security"
+
+    def test_type_field_in_dict(self):
+        event = OWASPLogEvent(
+            datetime="2026-01-01T00:00:00+00:00",
+            type="security",
+            appid="test.app",
+            event="test_event",
+            level="INFO",
+        )
+        d = event.to_dict()
+        assert d["type"] == "security"
+
+    def test_type_field_in_json(self):
+        event = OWASPLogEvent(
+            datetime="2026-01-01T00:00:00+00:00",
+            type="security",
+            appid="test.app",
+            event="test_event",
+            level="INFO",
+        )
+        parsed = json.loads(event.to_json())
+        assert parsed["type"] == "security"
+
+    def test_type_field_in_nested_json(self):
+        event = OWASPLogEvent(
+            datetime="2026-01-01T00:00:00+00:00",
+            type="security",
+            appid="test.app",
+            event="test_event",
+            level="INFO",
+        )
+        parsed = json.loads(event.to_json(nested_json_key=NESTED_JSON_KEY))
+        assert parsed[NESTED_JSON_KEY]["type"] == "security"
+
+    def test_type_field_order_in_dict(self):
+        """Verify 'type' appears right after 'datetime' in the serialized output."""
+        event = OWASPLogEvent(
+            datetime="2026-01-01T00:00:00+00:00",
+            type="security",
+            appid="test.app",
+            event="test_event",
+            level="INFO",
+        )
+        keys = list(event.to_dict().keys())
+        assert keys[0] == "datetime"
+        assert keys[1] == "type"
+
+
+class TestOWASPLoggerEmitsType:
+    """Ensure the OWASPLogger methods produce logs with type='security'."""
+
+    def test_log_event_contains_type_security(self, caplog):
+        logger = OWASPLogger(appid="test.app")
+        with caplog.at_level(logging.DEBUG):
+            logger.authn_login_success(userid="alice")
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        owasp_event = getattr(record, NESTED_JSON_KEY, None)
+        assert owasp_event is not None
+        assert owasp_event["type"] == "security"
+        parsed = json.loads(record.getMessage())
+        assert parsed[NESTED_JSON_KEY]["type"] == "security"
+
+    def test_multiple_event_types_contain_type_security(self, caplog):
+        logger = OWASPLogger(appid="test.app")
+        with caplog.at_level(logging.DEBUG):
+            logger.authn_login_fail(userid="bob")
+            logger.authz_fail(userid="bob", resource="/admin")
+            logger.sys_crash(reason="oom")
+            logger.session_created(userid="carol")
+        for record in caplog.records:
+            owasp_event = getattr(record, NESTED_JSON_KEY, None)
+            assert owasp_event is not None
+            assert owasp_event["type"] == "security"


### PR DESCRIPTION
Add a `type` field to `OWASPLogEvent`, always set to `"security"`, so all OWASP security logs are clearly identifiable. This aligns the actual log output with the documented format in the README.

## Changes

- **`model.py`** — Add `type: str` field to `OWASPLogEvent` (positioned between `datetime` and `appid`)
- **`logger.py`** — Set `type="security"` in `_log_event()`
- **`tests/test_placeholder.py`** — Add tests verifying the field appears in dict, JSON, nested JSON, and live logger output

Closes #8

---

Example of log (printed via `python examples/otel.py`):
```json
{
    "body": "Admin ananas-alex watered their plants",
    "severity_number": 13,
    "severity_text": "WARN",
    "attributes": {
        "owasp_event": {
            "datetime": "2026-04-01T15:50:39.047756+02:00",
            "type": "security",
            "appid": "example.appid",
            "event": "authz_admin:ananas-alex,watered_plants",
            "level": "WARNING",
            "description": "Admin ananas-alex watered their plants"
        },
        "code.file.path": "/home/aegis/Repositories/Canonical/owasp-logger/src/owasp_logger/logger.py",
        "code.function.name": "_log_event",
        "code.line.number": 36
    },
    "dropped_attributes": 0,
    "timestamp": "2026-04-01T13:50:39.047868Z",
    "observed_timestamp": "2026-04-01T13:50:39.047885Z",
    "trace_id": "0x00000000000000000000000000000000",
    "span_id": "0x0000000000000000",
    "trace_flags": 0,
    "resource": {
        "attributes": {
            "telemetry.sdk.language": "python",
            "telemetry.sdk.name": "opentelemetry",
            "telemetry.sdk.version": "1.33.1",
            "service.name": "example-service"
        },
        "schema_url": ""
    }
}
```